### PR TITLE
feat: add configuration for automated releases

### DIFF
--- a/.github/workflows/automerge-release-pr-bump.yml
+++ b/.github/workflows/automerge-release-pr-bump.yml
@@ -1,0 +1,47 @@
+name: Automerge release bump PR
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite: 
+    types:
+      - completed
+  status: {}
+  
+jobs:
+
+  autoapprove:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Autoapproving
+        uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'asyncapi-bot'
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  automerge:
+    needs: [autoapprove]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automerging
+        uses: pascalgn/automerge-action@v0.7.5
+        if: github.actor == 'asyncapi-bot'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_LOGIN: asyncapi-bot
+          MERGE_LABELS: ""
+          MERGE_METHOD: "squash"
+          MERGE_COMMIT_MESSAGE: "pull-request-title"
+          MERGE_RETRIES: "10"
+          MERGE_RETRY_SLEEP: "10000"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: 'Release NPM, GitHub, Docker'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Get version from package.json before release step
+        id: initversion
+        run: echo "::set-output name=version::$(npm run get-version --silent)"
+      - name: Release to NPM and GitHub
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_AUTHOR_NAME: asyncapi-bot
+          GIT_AUTHOR_EMAIL: info@asyncapi.io
+          GIT_COMMITTER_NAME: asyncapi-bot
+          GIT_COMMITTER_EMAIL: info@asyncapi.io
+        run: npm run release
+      - name: Get version from package.json after release step
+        id: extractver
+        run: echo "::set-output name=version::$(npm run get-version --silent)"
+      - name: Create Pull Request with updated package files
+        if: steps.initversion.outputs.version != steps.extractver.outputs.version
+        uses: peter-evans/create-pull-request@v2.4.4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          commit-message: 'chore(release): ${{ steps.extractver.outputs.version }}'
+          committer: asyncapi-bot <info@asyncapi.io>
+          author: asyncapi-bot <info@asyncapi.io>
+          title: 'chore(release): ${{ steps.extractver.outputs.version }}'
+          body: 'Version bump in package.json and package-lock.json for release [${{ steps.extractver.outputs.version }}](https://github.com/${{github.repository}}/releases/tag/v${{ steps.extractver.outputs.version }})'
+          branch: version-bump/${{ steps.extractver.outputs.version }}

--- a/.npmrc.template
+++ b/.npmrc.template
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - "8"
-deploy:
-  provider: script
-  script: "cp .npmrc.template $HOME/.npmrc && npm install && npm test && npm publish --access=public"
-  on:
-    tags: true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha --recursive",
-    "release": "semantic-release"
+    "release": "semantic-release",
+    "get-version": "echo $npm_package_version"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An AsyncAPI schema parser for OpenAPI 3.0.x and Swagger 2.x schemas.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --recursive"
+    "test": "mocha --recursive",
+    "release": "semantic-release"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "parser"
   ],
   "author": "Fran Mendez (fmvilas.com)",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/asyncapi/openapi-schema-parser/issues"
@@ -30,6 +33,33 @@
     "asyncapi-parser": "^0.14.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "mocha": "^7.1.0"
+    "mocha": "^7.1.0",
+    "@semantic-release/commit-analyzer": "^8.0.1",
+    "@semantic-release/github": "^7.0.4",
+    "@semantic-release/npm": "^7.0.3",
+    "@semantic-release/release-notes-generator": "^9.0.1",
+    "conventional-changelog-conventionalcommits": "^4.2.3",
+    "semantic-release": "^17.0.4"
+  },
+  "release": {
+    "branches": [
+      "master"
+    ],
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
+      "@semantic-release/npm",
+      "@semantic-release/github"
+    ]
   }
 }


### PR DESCRIPTION
Same as https://github.com/asyncapi/generator/pull/242 except of:
- no docker release
- no contribution guide and pr template as this will be handled in https://github.com/asyncapi/asyncapi/issues/355
- added step to run `npm test`
- avoided mistakes done with generator - package marked as public and removed travis


See also: https://github.com/asyncapi/parser-js/issues/52