### PR TITLE
refactor: Remove unnecessary semicolon from index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ async function parse({ message, defaultSchemaFormat }) {
   message['x-parser-original-payload'] = message.payload;
   message.payload = transformed;
   delete message.schemaFormat;
-};
+}
 
 function iterateSchema(schema) {
   if (schema.example !== undefined) {


### PR DESCRIPTION
**Description**

Remove superfluous semicolon from index.js

**Related issue(s)**
Resolves #10 