### PR TITLE
feat!: rewrite to TS and adjust to the v2 ParserJS (#142)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/parser": "^2.0.0-next-major.16",
+        "@asyncapi/parser": "^2.0.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -53,11 +53,11 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "2.0.0-next-major.16",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.0.0-next-major.16.tgz",
-      "integrity": "sha512-uQsQkPlBf16DyU9qPW6mmhSKLsQPxun97VkjT9E3/YssCbQkSDuENJHgs27K1Me/vXcIyfTmqstV7Vnr7vsbVw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.0.0.tgz",
+      "integrity": "sha512-xQm3LVChLGGTOo6OxGM4wIwTC7/uMHZvQMcGHnCvdyqcqn4H1sZQdE+MHhxPM7SnKNko86Pub0UDavwk0Jfwyw==",
       "dependencies": {
-        "@asyncapi/specs": "^4.1.0",
+        "@asyncapi/specs": "^5.0.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json-ref-resolver": "^3.1.5",
         "@stoplight/spectral-core": "^1.16.1",
@@ -69,6 +69,7 @@
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
         "avsc": "^5.7.5",
+        "conventional-changelog-conventionalcommits": "^5.0.0",
         "js-yaml": "^4.1.0",
         "jsonpath-plus": "^7.2.0",
         "node-fetch": "2.6.7",
@@ -80,6 +81,19 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/@asyncapi/parser/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@asyncapi/parser/node_modules/js-yaml": {
       "version": "4.1.0",
@@ -93,11 +107,25 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-4.2.0.tgz",
-      "integrity": "sha512-V9bFzUGNXrpsyennEXNZaPvdoFYYoeUYYAGiQVYsGsUsF/IL/G40NpE9u6nPeXGj8sZgjKlUG6iP39T0DYtSlQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.0.0.tgz",
+      "integrity": "sha512-ua89EYhNAL6IPrX/P5O+K5DEQYfMXwHhG207+8yCSvcVXevZ1wLEj/nsNHYi2jBRDr10kp7+O99tGWIdASJtOA==",
       "dependencies": {
-        "@types/json-schema": "^7.0.11"
+        "@types/json-schema": "^7.0.11",
+        "conventional-changelog-conventionalcommits": "^5.0.0"
+      }
+    },
+    "node_modules/@asyncapi/specs/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3351,8 +3379,7 @@
     "node_modules/array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-      "dev": true
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
     },
     "node_modules/array-includes": {
       "version": "3.1.5",
@@ -3950,7 +3977,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
       "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-      "dev": true,
       "dependencies": {
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
@@ -4428,7 +4454,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
       "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "dev": true,
       "dependencies": {
         "is-obj": "^2.0.0"
       },
@@ -6432,7 +6457,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12530,7 +12554,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true,
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
@@ -14312,11 +14335,11 @@
       }
     },
     "@asyncapi/parser": {
-      "version": "2.0.0-next-major.16",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.0.0-next-major.16.tgz",
-      "integrity": "sha512-uQsQkPlBf16DyU9qPW6mmhSKLsQPxun97VkjT9E3/YssCbQkSDuENJHgs27K1Me/vXcIyfTmqstV7Vnr7vsbVw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.0.0.tgz",
+      "integrity": "sha512-xQm3LVChLGGTOo6OxGM4wIwTC7/uMHZvQMcGHnCvdyqcqn4H1sZQdE+MHhxPM7SnKNko86Pub0UDavwk0Jfwyw==",
       "requires": {
-        "@asyncapi/specs": "^4.1.0",
+        "@asyncapi/specs": "^5.0.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json-ref-resolver": "^3.1.5",
         "@stoplight/spectral-core": "^1.16.1",
@@ -14328,6 +14351,7 @@
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
         "avsc": "^5.7.5",
+        "conventional-changelog-conventionalcommits": "^5.0.0",
         "js-yaml": "^4.1.0",
         "jsonpath-plus": "^7.2.0",
         "node-fetch": "2.6.7",
@@ -14340,6 +14364,16 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
+        "conventional-changelog-conventionalcommits": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+          "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+          "requires": {
+            "compare-func": "^2.0.0",
+            "lodash": "^4.17.15",
+            "q": "^1.5.1"
+          }
+        },
         "js-yaml": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -14351,11 +14385,24 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-4.2.0.tgz",
-      "integrity": "sha512-V9bFzUGNXrpsyennEXNZaPvdoFYYoeUYYAGiQVYsGsUsF/IL/G40NpE9u6nPeXGj8sZgjKlUG6iP39T0DYtSlQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.0.0.tgz",
+      "integrity": "sha512-ua89EYhNAL6IPrX/P5O+K5DEQYfMXwHhG207+8yCSvcVXevZ1wLEj/nsNHYi2jBRDr10kp7+O99tGWIdASJtOA==",
       "requires": {
-        "@types/json-schema": "^7.0.11"
+        "@types/json-schema": "^7.0.11",
+        "conventional-changelog-conventionalcommits": "^5.0.0"
+      },
+      "dependencies": {
+        "conventional-changelog-conventionalcommits": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+          "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+          "requires": {
+            "compare-func": "^2.0.0",
+            "lodash": "^4.17.15",
+            "q": "^1.5.1"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -16812,8 +16859,7 @@
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-      "dev": true
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
     },
     "array-includes": {
       "version": "3.1.5",
@@ -17257,7 +17303,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
       "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-      "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
@@ -17617,7 +17662,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
       "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
       }
@@ -19108,8 +19152,7 @@
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
     "is-path-cwd": {
       "version": "2.2.0",
@@ -23529,8 +23572,7 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@asyncapi/parser": "^2.0.0-next-major.16",
+    "@asyncapi/parser": "^2.0.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
     "ajv": "^8.11.0",
     "ajv-errors": "^3.0.0",


### PR DESCRIPTION
    Co-authored-by: Sergio Moya <1083296+smoya@users.noreply.github.com>

**Description**
 This PR updates `@asyncapi/parser` dependency to the major version v2.0.0.
It also forces the release of a new major version (v3) of this schema parser as the previous script failed: 

```
[1:24:26 PM] [semantic-release] › ℹ  The local branch master is behind the remote one, therefore a new version won't be published.
```
> Source: https://github.com/asyncapi/openapi-schema-parser/actions/runs/4831058189/jobs/8608104975#step:9:35