### PR TITLE
chore: add new codeowner of the project

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @fmvilas @smoya @asyncapi-bot-eve
+* @fmvilas @smoya @asyncapi-bot-eve @AayushSaini101


### PR DESCRIPTION
Most of the Maintainers are inactive in the parser. I am already maintaining the CLI project since for a very long period of time, would like to maintain in the future : )